### PR TITLE
fix: use anchor tag for RegisterButton to open URLs securely

### DIFF
--- a/frontend/src/components/DomainCard.tsx
+++ b/frontend/src/components/DomainCard.tsx
@@ -174,6 +174,8 @@ export const RegisterButton = ({ domain, showText = false }: { domain: string, s
       onClick={handleClick}
       title={hoverText}
       href={targetUrl}
+      target="_blank"
+      rel="noopener noreferrer"
     >
       {ActionIcons.register}
       {showText && <div className="text-sm">Register</div>}

--- a/frontend/src/components/DomainCard.tsx
+++ b/frontend/src/components/DomainCard.tsx
@@ -162,20 +162,22 @@ export const RegisterButton = ({ domain, showText = false }: { domain: string, s
 
   const handleClick = () => {
     trackEventSafe("ClickRegister");
-    window.open(`https://www.netim.com/en/domain-name/search?partnerid=${NETIM_PARTNER_ID}&domain=${domain}`, '_blank', 'noopener,noreferrer');
   };
   const shapeStyling = showText ? "btn-lg" : "btn-square";
   const hoverText = `Register ${domain}`
+  const targetUrl = `https://www.netim.com/en/domain-name/search?partnerid=${NETIM_PARTNER_ID}&domain=${domain}`;
+
 
   return (
-    <button
+    <a
       className={`btn btn-primary ${shapeStyling}`}
       onClick={handleClick}
       title={hoverText}
+      href={targetUrl}
     >
       {ActionIcons.register}
       {showText && <div className="text-sm">Register</div>}
-    </button>
+    </a>
   );
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change `RegisterButton` to use an `anchor` tag for secure URL opening in `DomainCard.tsx`.
> 
>   - **Behavior**:
>     - Change `RegisterButton` from `button` to `anchor` tag in `DomainCard.tsx`.
>     - Ensures URLs open securely with `target="_blank"` and `rel="noopener noreferrer"`.
>   - **Misc**:
>     - Remove `window.open` call from `handleClick` in `RegisterButton`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=yablochko8%2Fdreamy-domains&utm_source=github&utm_medium=referral)<sup> for 402c7d69ae9cf8809d1cd841904227242f7a8fce. You can [customize](https://app.ellipsis.dev/yablochko8/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->